### PR TITLE
Rename register & Add log_level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .bundle
 Gemfile.lock
 vendor
+td-agent.conf

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP and HTTPS endpo
 ## Configs
 
     <match *>
-      type            out_https
+      type            https
       use_ssl         true
       include_tag     true
       include_timestamp true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP and HTTPS endpo
 ## Configs
 
     <match *>
-      type            http
+      type            out_https
       use_ssl         true
       include_tag     true
       include_timestamp true

--- a/fluent-plugin-out-http.gemspec
+++ b/fluent-plugin-out-http.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-out-https"
-  gem.version       = "0.1.0"
+  gem.version       = "0.1.1"
   gem.authors       = ["Kazunori Sato"]
   gem.email         = ["kazunori279@gmail.com"]
   gem.summary       = %q{A generic Fluentd output plugin to send logs to an HTTPS endpoint}

--- a/lib/fluent/plugin/out_https.rb
+++ b/lib/fluent/plugin/out_https.rb
@@ -1,5 +1,10 @@
 class Fluent::HTTPSOutput < Fluent::Output
-  Fluent::Plugin.register_output('http', self)
+  Fluent::Plugin.register_output('out_https', self)
+
+  # Define `log` method for v0.10.42 or earlier
+  unless method_defined?(:log)
+    define_method("log") { $log }
+  end
 
   def initialize
     super

--- a/lib/fluent/plugin/out_https.rb
+++ b/lib/fluent/plugin/out_https.rb
@@ -1,5 +1,5 @@
 class Fluent::HTTPSOutput < Fluent::Output
-  Fluent::Plugin.register_output('out_https', self)
+  Fluent::Plugin.register_output('https', self)
 
   # Define `log` method for v0.10.42 or earlier
   unless method_defined?(:log)


### PR DESCRIPTION
```
 Fluent::Plugin.register_output('http', self)
```

「http」という名前でpluginを登録されているのですが、fluentdのデフォルトインストールされている「in_http」のregister名と重複しております。そのため、in_httpと同時使用すると不具合が生じてしまいます。READMEの方も修正させていただきましたので、内容ご確認頂けますでしょうか。

併せまして、Fluentd v0.10.43 のlog_level対応もさせていただきました。
併せてご確認よろしくお願いします。
