### PR TITLE
Added hybrid serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 
 ## 0.1.1
 * Added include_timestamp option
+
+## 0.1.2
+* Added `hybrid` serializer (no tests though)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A generic [fluentd][1] output plugin for sending logs to an HTTP and HTTPS endpo
 * Set `include_tag` to true to include fluentd tag in the event log as a property 
 * Set `include_timestamp` to true to include timestamp (UNIX time) in the event log as a property
 * By default, it does not verify the https server. Use VERIFY_PEER and place the cert.pem to the location specified by OpenSSL::X509::DEFAULT_CERT_FILE. 
+* The serializer `hybrid` will convert any hash or array to a JSON string before form-encoding.
 * Majority of the code are cloned from  [fluent-plugin-out-http][2]
 
   [1]: http://fluentd.org/


### PR DESCRIPTION
I am not able to write tests (lack of knowlege) but i needed this functionality really badly. Maybe you could write some tests (if necessary) and merge it?

I tested it in td-agent and it did not affect the json, nor form serializer in their output.
This hybrid serializer will JSON-encode any Hash or Array before the form-encoding.
